### PR TITLE
Add composer support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+	"name": "gsa/wp-digitalgov-i14y-indexer",
+	"description": "This plugin allows your agency to add pages from your agency's WordPress website into the DigitalGov Search platform.",
+	"keywords": [
+		"wordpress"
+	],
+	"license": "CC0",
+	"type": "wordpress-plugin",
+	"require": {
+		"composer/installers": "~1.0"
+	 }
+}


### PR DESCRIPTION
A very simple composer file.

Without this plugin in the main wordpress plugins repository to get picked up by wpackagist, we had to maintain a private fork with a composer.json in it in order to add it to a composer managed wordpress site.

As mentioned in: https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md You can also change the plugin path to digital-search by adding this to the extra section of your main composer.json:

``` JSON
"installer-paths": {
  "wp-content/plugins/digitalgov-search": ["gsa/wp-digitalgov-i14y-indexer"]
}
```
